### PR TITLE
do not override users compiler and compiler flags, use CXX instead CC and CFLAGS tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
-
-CC = g++ -Wall -ggdb
-CC = g++ -pg
-CC = g++
+CXX ?= g++
 
 # without OpenMP
 
@@ -9,9 +6,9 @@ CC = g++
 # in command line: 
 # make openmp=yes
 ifeq ($(openmp),no)
-  CCFLAGS = -DNO_OPENMP
+  CXXFLAGS += -DNO_OPENMP
 else
-  CCFLAGS = -fopenmp
+  CXXFLAGS += -fopenmp
 endif
 
 # support debugging
@@ -19,13 +16,13 @@ endif
 # make debug=yes
 # make openmp=yes debug=yes
 ifeq ($(debug),yes)
-CCFLAGS += -ggdb
+CXXFLAGS += -ggdb
 else
-CCFLAGS += -O2
+CXXFLAGS ?= -O2
 endif
 
 ifdef MAX_SEQ
-CCFLAGS += -DMAX_SEQ=$(MAX_SEQ)
+CXXFLAGS += -DMAX_SEQ=$(MAX_SEQ)
 endif
 
 #LDFLAGS = -static -o
@@ -34,10 +31,10 @@ LDFLAGS += -o
 PROGS = cd-hit cd-hit-est cd-hit-2d cd-hit-est-2d cd-hit-div cd-hit-454
 
 # Propagate hardening flags
-CCFLAGS := $(CPPFLAGS) $(CCFLAGS) $(CXXFLAGS)
+CXXFLAGS := $(CPPFLAGS) $(CXXFLAGS)
 
 .c++.o:
-	$(CC) $(CCFLAGS) -c $<
+	$(CXX) $(CXXFLAGS) -c $<
 
 all: $(PROGS)
 
@@ -47,49 +44,49 @@ clean:
 # programs
 
 cd-hit: cdhit-common.o cdhit-utility.o cdhit.o
-	$(CC) $(CCFLAGS) cdhit.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit
+	$(CXX) $(CXXFLAGS) cdhit.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit
 
 cd-hit-2d: cdhit-common.o cdhit-utility.o cdhit-2d.o
-	$(CC) $(CCFLAGS) cdhit-2d.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit-2d
+	$(CXX) $(CXXFLAGS) cdhit-2d.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit-2d
 
 cd-hit-est: cdhit-common.o cdhit-utility.o cdhit-est.o
-	$(CC) $(CCFLAGS) cdhit-est.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit-est
+	$(CXX) $(CXXFLAGS) cdhit-est.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit-est
 
 cd-hit-est-2d: cdhit-common.o cdhit-utility.o cdhit-est-2d.o
-	$(CC) $(CCFLAGS) cdhit-est-2d.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit-est-2d
+	$(CXX) $(CXXFLAGS) cdhit-est-2d.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit-est-2d
 
 cd-hit-div: cdhit-common.o cdhit-utility.o cdhit-div.o
-	$(CC) $(CCFLAGS) cdhit-div.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit-div
+	$(CXX) $(CXXFLAGS) cdhit-div.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit-div
 
 cd-hit-454: cdhit-common.o cdhit-utility.o cdhit-454.o
-	$(CC) $(CCFLAGS) cdhit-454.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit-454
+	$(CXX) $(CXXFLAGS) cdhit-454.o cdhit-common.o cdhit-utility.o $(LDFLAGS) cd-hit-454
 
 # objects
 cdhit-common.o: cdhit-common.c++ cdhit-common.h
-	$(CC) $(CCFLAGS) cdhit-common.c++ -c
+	$(CXX) $(CXXFLAGS) cdhit-common.c++ -c
 
 cdhit-utility.o: cdhit-utility.c++ cdhit-utility.h
-	$(CC) $(CCFLAGS) cdhit-utility.c++ -c
+	$(CXX) $(CXXFLAGS) cdhit-utility.c++ -c
 
 cdhit.o: cdhit.c++ cdhit-utility.h
-	$(CC) $(CCFLAGS) cdhit.c++ -c
+	$(CXX) $(CXXFLAGS) cdhit.c++ -c
 
 cdhit-2d.o: cdhit-2d.c++ cdhit-utility.h
-	$(CC) $(CCFLAGS) cdhit-2d.c++ -c
+	$(CXX) $(CXXFLAGS) cdhit-2d.c++ -c
 
 cdhit-est.o: cdhit-est.c++ cdhit-utility.h
-	$(CC) $(CCFLAGS) cdhit-est.c++ -c
+	$(CXX) $(CXXFLAGS) cdhit-est.c++ -c
 
 cdhit-est-2d.o: cdhit-est-2d.c++ cdhit-utility.h
-	$(CC) $(CCFLAGS) cdhit-est-2d.c++ -c
+	$(CXX) $(CXXFLAGS) cdhit-est-2d.c++ -c
 
 cdhit-div.o: cdhit-div.c++ cdhit-common.h
-	$(CC) $(CCFLAGS) cdhit-div.c++ -c
+	$(CXX) $(CXXFLAGS) cdhit-div.c++ -c
 
 cdhit-454.o: cdhit-454.c++ cdhit-common.h
-	$(CC) $(CCFLAGS) cdhit-454.c++ -c
+	$(CXX) $(CXXFLAGS) cdhit-454.c++ -c
 
-PREFIX ?= /usr/local/bin
+PREFIX ?= $(DESTDIR)/usr/local/bin
 
 install:
 	for prog in $(PROGS); do \

--- a/cd-hit-auxtools/Makefile
+++ b/cd-hit-auxtools/Makefile
@@ -1,9 +1,8 @@
+CXX ?= g++
 
-CC = g++
-
-CFLAGS = -Wall -Wno-unused -I. -Imintlib
+CXXFLAGS ?= -Wall -Wno-unused
 LFLAGS = -fPIC
-
+CPPFLAGS = -I. -Imintlib
 
 UNAME = $(shell uname)
 
@@ -18,7 +17,7 @@ endif
 ifeq ($(debug),yes)
 CFLAGS += -ggdb
 else
-CFLAGS += -O2
+CXXFLAGS ?= -O2
 endif
 
 
@@ -32,16 +31,16 @@ all: cd-hit-dup cd-hit-lap read-linker
 .SUFFIXES: .c .obj .cpp .cc .cxx .C
 
 .cxx.o:
-	$(CC) -c $(CFLAGS) -o $@ $<
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) -o $@ $<
 
 cd-hit-dup: $(OBJECTS) cdhit-dup.o
-	$(CC) $(LFLAGS) $(OBJECTS) cdhit-dup.o -o cd-hit-dup
+	$(CXX) $(CXXFLAGS) $(LFLAGS) $(OBJECTS) cdhit-dup.o -o cd-hit-dup
 
 cd-hit-lap: $(OBJECTS) cdhit-lap.o
-	$(CC) $(LFLAGS) $(OBJECTS) cdhit-lap.o -o cd-hit-lap
+	$(CXX) $(CXXFLAGS) $(LFLAGS) $(OBJECTS) cdhit-lap.o -o cd-hit-lap
 
 read-linker: $(OBJECTS) read-linker.o
-	$(CC) $(LFLAGS) $(OBJECTS) read-linker.o -o read-linker
+	$(CXX) $(CXXFLAGS) $(LFLAGS) $(OBJECTS) read-linker.o -o read-linker
 
 clean:
 	rm $(OBJECTS) cdhit-dup.o cdhit-lap.o read-linker.o


### PR DESCRIPTION
do not override users compiler and compiler flags

use CXX instead CC variable because we need a C++ compiler

do not force optimization if user has some CXXFLAGS already in the environment