### PR TITLE
Fix cd-hit-dup for mismatches

### DIFF
--- a/cd-hit-auxtools/cdhit-dup.cxx
+++ b/cd-hit-auxtools/cdhit-dup.cxx
@@ -369,7 +369,7 @@ void ClusterDuplicate( SequenceList & seqlist, Array<SequenceCluster> & clusters
 
 		int start = primer;
 		dep = 0;//HashingDepth( shared, min );
-		while( maxmm == 0 && clustered == false && (start+2*shared) <= qlen && start <= primer + (maxmm+1) * shared ){
+		while( maxmm > 0 && clustered == false && (start+2*shared) <= qlen && start <= primer + (maxmm+1) * shared ){
 			hash = MakeHash( seq, start, shared );
 			node = middles[start][ dep ].Find( hash );
 			start += shared;


### PR DESCRIPTION
Previously would only cluster perfect matches except for mismatches close to the end (~10 bp)

Addresses #31 